### PR TITLE
fix(protobuf): work around upstream protobuf change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     install_requires=[
         'grpcio==1.42.0',
-        'googleapis-common-protos==1.56.2',
+        'googleapis-common-protos>=1.56.2,<2',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     install_requires=[
         'grpcio==1.42.0',
-        'googleapis-common-protos==1.52.0',
+        'googleapis-common-protos==1.56.2',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package


### PR DESCRIPTION
Fixes #10

So, what's all this then?  Google released a new major version of
Protocol Buffers, and corresponding new `protobuf` package for Python.
See
https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
for details.

Since `strongdm` doesn't constrain the maximum version of `protobuf`, and
neither do any of its upstream dependencies(currently), the following
occurs when `protobuf` is allowed to float above v4:

```
============================= test session starts ==============================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0 -- /home/circleci/circleci/strongdm_datasource_generator_venv/bin/python
cachedir: .pytest_cache
rootdir: /home/circleci/circleci
plugins: socket-0.5.1, mock-3.7.0, cov-3.0.0
collecting ... collecting 2 items / 1 error                                                   collected 28 items / 2 errors

==================================== ERRORS ====================================
____ ERROR collecting tools/strongdm_datasource_generator/tests/test_cli.py ____
...
tools/strongdm_datasource_generator/strongdm_utils.py:7: in <module>
    import strongdm
strongdm_datasource_generator_venv/lib/python3.8/site-packages/strongdm/__init__.py:21: in <module>
    from .client import *
strongdm_datasource_generator_venv/lib/python3.8/site-packages/strongdm/client.py:25: in <module>
    from . import svc
strongdm_datasource_generator_venv/lib/python3.8/site-packages/strongdm/svc.py:19: in <module>
    from . import plumbing
strongdm_datasource_generator_venv/lib/python3.8/site-packages/strongdm/plumbing.py:21: in <module>
    from google.rpc import status_pb2
strongdm_datasource_generator_venv/lib/python3.8/site-packages/google/rpc/status_pb2.py:50: in <module>
    _descriptor.FieldDescriptor(
strongdm_datasource_generator_venv/lib/python3.8/site-packages/google/protobuf/descriptor.py:560: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
E
E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
...
```
:sad-trombone:

However, a few days ago, a new point release of
`googleapis-common-protos` emerged, which includes a dependency
constraint on `protobuf<4`.  I suspect a real fix to this problem will
require a new release of this module with the protobuf files properly
rebuilt; however, as an immediate fix, please consider merging this PR
and then promptly publishing a new release of `strongdm` so that we can
pin to `strongdm>2.4.0,<3` or some such.
